### PR TITLE
chore: expose trait implementation helpers

### DIFF
--- a/cargo_pup_lint_config/src/struct_lint/builder.rs
+++ b/cargo_pup_lint_config/src/struct_lint/builder.rs
@@ -127,6 +127,22 @@ impl<'a> StructConstraintBuilder<'a> {
         self
     }
 
+    /// Add a rule requiring the struct to implement a given trait
+    pub fn must_implement_trait(mut self, trait_path: impl Into<String>) -> Self {
+        self.add_rule_internal(StructRule::ImplementsTrait(
+            trait_path.into(),
+            self.current_severity,
+        ));
+        self
+    }
+
+    /// Add a rule requiring the struct NOT to implement a given trait
+    pub fn must_not_implement_trait(mut self, trait_path: impl Into<String>) -> Self {
+        let inner = StructRule::ImplementsTrait(trait_path.into(), self.current_severity);
+        self.add_rule_internal(StructRule::Not(Box::new(inner)));
+        self
+    }
+
     /// Add a rule requiring the struct to have public visibility
     pub fn must_be_public(mut self) -> Self {
         self.add_rule_internal(StructRule::MustBePublic(self.current_severity));

--- a/test_app/Cargo.lock
+++ b/test_app/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "test_app"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "cargo_pup_lint_config",

--- a/test_app/tests/pup_ron_test.rs
+++ b/test_app/tests/pup_ron_test.rs
@@ -82,11 +82,11 @@ fn test_lint_config() {
     // Trait restrictions
     builder.struct_lint()
         .lint_named("trait_restrictions")
-        .matching(|m|
-        m.implements_trait("^test_app::trait_impl::MyTrait$"))
+        .matching(|m| m.implements_trait("^test_app::trait_impl::MyTrait$"))
         .with_severity(Severity::Warn)
-        .must_be_named(".*MyTraitImpl$".into())        
+        .must_be_named(".*MyTraitImpl$".into())
         .must_be_private()
+        .must_implement_trait("test_app::trait_impl::MyTrait")
         .build();
         
     // Result error implementation check


### PR DESCRIPTION
Expose `must_implement_trait` and `must_not_implement_trait` for structs in builder API.
