### PR TITLE
chore: Bump toolchain and pre-release for 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "cargo_pup"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "cargo_pup_common"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "cargo_pup_lint_config"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "cargo_pup_common",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "cargo_pup_lint_impl"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "cargo_pup_common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["test_app"]
 
 [package]
 name = "cargo_pup"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "A Rust architectural linting tool that integrates with rustc to enforce architectural patterns and boundaries"
 license = "Apache-2.0"
@@ -34,9 +34,9 @@ anyhow = { workspace = true }
 tempfile = { workspace = true }
 ron = { workspace = true }
 cargo_metadata = { workspace = true }
-cargo_pup_common = { path = "cargo_pup_common", version = "=0.1.2" }
-cargo_pup_lint_impl = { path = "cargo_pup_lint_impl", version = "=0.1.2" }
-cargo_pup_lint_config = { path = "cargo_pup_lint_config", version = "=0.1.2" }
+cargo_pup_common = { path = "cargo_pup_common", version = "=0.1.3" }
+cargo_pup_lint_impl = { path = "cargo_pup_lint_impl", version = "=0.1.3" }
+cargo_pup_lint_config = { path = "cargo_pup_lint_config", version = "=0.1.3" }
 
 #
 # These bits are just to keep rust rover happy.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ First, make sure to install [rustup](https://rustup.rs/) to manage your local ru
 
 Then install pup; **you must use this nightly toolchain, as pup depends on compiler internals that are otherwise unavailable!**
 ```bash
-cargo +nightly-2025-05-31 install cargo_pup
+cargo +nightly-2025-07-25 install cargo_pup
 ```
 
 ## Getting Started
@@ -120,7 +120,7 @@ First, add the following to your `Cargo.toml`:
 
 ```toml
 [dev-dependencies]
-cargo_pup_lint_config = "0.1.2"
+cargo_pup_lint_config = "0.1.3"
 ```
 
 ## Examples

--- a/cargo_pup_common/Cargo.toml
+++ b/cargo_pup_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo_pup_common"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Common utilities and shared components for cargo-pup architectural linting tool"
 license = "Apache-2.0"

--- a/cargo_pup_lint_config/Cargo.toml
+++ b/cargo_pup_lint_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo_pup_lint_config"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Configuration and rule builder utilities for cargo-pup architectural linting"
 license = "Apache-2.0"
@@ -13,4 +13,4 @@ serde.workspace = true
 ron.workspace = true
 tempfile.workspace = true
 anyhow.workspace = true
-cargo_pup_common = { path = "../cargo_pup_common", version = "=0.1.2" }
+cargo_pup_common = { path = "../cargo_pup_common", version = "=0.1.3" }

--- a/cargo_pup_lint_config/README.md
+++ b/cargo_pup_lint_config/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dev-dependencies]
-cargo_pup_lint_config = "0.1.2"
+cargo_pup_lint_config = "0.1.3"
 ```
 
 ## Example

--- a/cargo_pup_lint_config/src/module_lint/builder.rs
+++ b/cargo_pup_lint_config/src/module_lint/builder.rs
@@ -8,11 +8,11 @@ use crate::{ConfiguredLint, Severity};
 /// Extension trait that adds module linting capabilities to LintBuilder
 pub trait ModuleLintExt {
     /// Start building a module lint rule
-    fn module_lint(&mut self) -> ModuleLintBuilder;
+    fn module_lint(&mut self) -> ModuleLintBuilder<'_>;
 }
 
 impl ModuleLintExt for LintBuilder {
-    fn module_lint(&mut self) -> ModuleLintBuilder {
+    fn module_lint(&mut self) -> ModuleLintBuilder<'_> {
         ModuleLintBuilder { parent: self }
     }
 }

--- a/cargo_pup_lint_config/src/struct_lint/builder.rs
+++ b/cargo_pup_lint_config/src/struct_lint/builder.rs
@@ -8,11 +8,11 @@ use crate::{ConfiguredLint, Severity};
 /// Extension trait that adds struct linting capabilities to LintBuilder
 pub trait StructLintExt {
     /// Start building a struct lint rule
-    fn struct_lint(&mut self) -> StructLintBuilder;
+    fn struct_lint(&mut self) -> StructLintBuilder<'_>;
 }
 
 impl StructLintExt for LintBuilder {
-    fn struct_lint(&mut self) -> StructLintBuilder {
+    fn struct_lint(&mut self) -> StructLintBuilder<'_> {
         StructLintBuilder { parent: self }
     }
 }

--- a/cargo_pup_lint_impl/Cargo.toml
+++ b/cargo_pup_lint_impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo_pup_lint_impl"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Core lint implementations and rustc integration for cargo-pup architectural linting"
 license = "Apache-2.0"
@@ -9,8 +9,8 @@ homepage = "https://github.com/datadog/cargo-pup"
 readme = "README.md"
 
 [dependencies]
-cargo_pup_lint_config = { path = "../cargo_pup_lint_config", version = "=0.1.2" }
-cargo_pup_common = { path = "../cargo_pup_common", version = "=0.1.2" }
+cargo_pup_lint_config = { path = "../cargo_pup_lint_config", version = "=0.1.3" }
+cargo_pup_common = { path = "../cargo_pup_common", version = "=0.1.3" }
 anyhow.workspace = true
 regex.workspace = true
 serde_json.workspace = true

--- a/cargo_pup_lint_impl/src/lib.rs
+++ b/cargo_pup_lint_impl/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(rustc_private)]
 // This product includes software developed at Datadog (https://www.datadoghq.com/) Copyright 2024 Datadog, Inc.
-#![feature(let_chains)]
 #![feature(array_windows)]
 #![feature(try_blocks)]
 

--- a/cargo_pup_lint_impl/src/lints/struct_lint/lint.rs
+++ b/cargo_pup_lint_impl/src/lints/struct_lint/lint.rs
@@ -128,10 +128,10 @@ impl StructLint {
             // Get parameter environment for the struct
             let param_env = ctx.param_env;
 
-            // For each trait in the crate, check if:
+            // For each trait in all crates, check if:
             // 1. The trait name matches our pattern
             // 2. The struct implements the trait
-            for trait_def_id in ctx.tcx.all_traits() {
+            for trait_def_id in ctx.tcx.all_traits_including_private() {
                 // Get the full canonical trait name
                 let full_trait_name =
                     queries::get_full_canonical_trait_name_from_def_id(&ctx.tcx, trait_def_id);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-05-31"
+channel = "nightly-2025-07-25"
 components = ["llvm-tools-preview", "rustc-dev", "rust-analyzer", "rust-src"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,6 @@
 //!
 //!
 
-#![feature(let_chains)]
 #![feature(array_windows)]
 #![feature(try_blocks)]
 #![warn(rust_2018_idioms, unused_lifetimes)]

--- a/src/pup_driver.rs
+++ b/src/pup_driver.rs
@@ -1,6 +1,5 @@
 #![feature(rustc_private)]
 // This product includes software developed at Datadog (https://www.datadoghq.com/) Copyright 2024 Datadog, Inc.
-#![feature(let_chains)]
 #![feature(array_windows)]
 #![feature(try_blocks)]
 


### PR DESCRIPTION
This bumps the toolchain to nightly 2025-07-25, and prepares for release.

The only impacting change in rustc is https://github.com/rust-lang/rust/pull/143038, which sees `all_traits` renamed to `all_traits_including_private` for clarity, but preserving the same behaviour.

